### PR TITLE
Use parameter rows to specify amount of rows from slack feed returned…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ You need some configuration settings in the `example_config.py` file :
 - PORT XX - Listening on port
 - THREADED True / False
 
+## Trello
 JSON - which has info on Trello boards :
 - DEBUG True / False - Debug mode in Flask
 - AUTH_KEY - Trello auth key.
@@ -27,7 +28,16 @@ XPTRE = { 'AUTH_KEY':'your_auth_key_to_trello',
 }
 ```
 
+It is possible to hide lists in your Trello board by using parameter ``` hide ```.
+Example: ``` http://localhost/myboard?hide=1,3,4 ``` , which will hide list number 1, 3 and 4.
+
+## Slack
 Not related to Trello, however implemented possibility to view a channel from [Slack](https://www.slack.com)
 A token is needed from Slack in the configuration file. 
 - SLACK = ``` {'TOKEN': 'your_token'} ```
 Access the channel by using url ``` http://yourserver/slack/<channelname> ```
+
+Default return is the last 8 rows from feed. It is possible to use parameter ``` rows ``` to specify 
+number of rows returned. (Max 20 rows)
+
+Example: ``` http://localhost/slack/mychannel?rows=10 ```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -46,8 +46,9 @@ def display_board(board_url):
 
 
 @app.route('/slack/<channel_name>', methods=['GET'])
-def display_board_as_table(channel_name):
-    return render_template("slack/channel_feed.html", data=channel_feed(slacker, channel_name))
+def display_slack_channel(channel_name):
+    numberofrows = request.args.get('rows')
+    return render_template("slack/channel_feed.html", data=channel_feed(slacker, channel_name, numberofrows))
 
 
 @app.route('/slack/image', methods=['GET'])

--- a/app/mod_trello/controllers.py
+++ b/app/mod_trello/controllers.py
@@ -30,9 +30,9 @@ def display_board(trello=None, config=None):
     return myboard.get_data()
 
 
-def feed_from_slack_channel(slacker=None, channel_name=None):
+def feed_from_slack_channel(slacker=None, channel_name=None, numberofrows=None):
 
-    slack_feed = SlackFeed(slacker)
+    slack_feed = SlackFeed(slacker, numberofrows)
     channel_feed = slack_feed.feed_from_channel(channel_name)
     channel_feed = {'channel_name': channel_name, 'messages': channel_feed}
 

--- a/app/mod_trello/models.py
+++ b/app/mod_trello/models.py
@@ -75,10 +75,11 @@ class TreBoard:
 
 
 class SlackFeed:
-    """Trello Board wrapper class"""
+    """Slack wrapper class"""
 
-    def __init__(self, slacker=None):
+    def __init__(self, slacker=None, numberofrows=None):
 
+        self.numberofrows = 8 if (numberofrows is None) or (int(numberofrows)>20) else numberofrows
         self.slacker = slacker
         emojies_response = self.slacker.emoji.list()
         self.slackemojies = emojies_response.body['emoji']
@@ -94,7 +95,7 @@ class SlackFeed:
             i += 1
 
         channel_id = channel_list[i].get('id')
-        history_response = self.slacker.channels.history(channel_id, '0', '0', 8, False, False)
+        history_response = self.slacker.channels.history(channel_id, '0', '0', self.numberofrows, False, False)
         messages = history_response.body['messages']
         # sort messages - oldest first - ts = timestamp
         messages = sorted(messages, key=lambda message: message['ts'])


### PR DESCRIPTION
Use parameter rows to specify amount of rows from slack feed returned… and updated README.

Example : 
`http://localhost/slack/channelname?rows=10` - which will return 10 rows.